### PR TITLE
Fix docker-compose up issue with pg image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,8 @@ services:
     ports:
       - 127.0.0.1:5432:5432
     restart: always
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     logging:
       <<: *logging_default
     volumes:


### PR DESCRIPTION
The db container is unable to start due to a breaking behavior change in
docker-librar/postgres:

https://github.com/docker-library/postgres/issues/681

This is the easy fix for localhost development, however documentation should be updated to advise
users on how to configure production environments securely.

fixes #84 